### PR TITLE
Add useful tags to template

### DIFF
--- a/draft-todo-yourname-protocol.md
+++ b/draft-todo-yourname-protocol.md
@@ -24,6 +24,13 @@ abbrev: "TODO - Abbreviation"
 category: info
 
 docname: draft-todo-yourname-protocol-latest
+submissiontype: IETF
+stand_alone: yes
+ipr: trust200902
+pi: [toc, sortrefs, symrefs]
+number:
+date:
+consensus:
 v: 3
 area: AREA
 workgroup: WG Working Group
@@ -35,6 +42,9 @@ venue:
   arch: https://example.com/WG
   github: USER/REPO
   latest: https://example.com/LATEST
+keyword:
+ - TODO1
+ - TODO2
 
 author:
  -

--- a/draft-todo-yourname-protocol.md
+++ b/draft-todo-yourname-protocol.md
@@ -25,16 +25,15 @@ category: info
 
 docname: draft-todo-yourname-protocol-latest
 submissiontype: IETF
-stand_alone: yes
-ipr: trust200902
-pi: [toc, sortrefs, symrefs]
 number:
 date:
-consensus:
+consensus: true
 v: 3
 area: AREA
 workgroup: WG Working Group
-keyword: Internet-Draft
+keyword:
+ - TODO1
+ - TODO2
 venue:
   group: WG
   type: Working Group
@@ -42,9 +41,6 @@ venue:
   arch: https://example.com/WG
   github: USER/REPO
   latest: https://example.com/LATEST
-keyword:
- - TODO1
- - TODO2
 
 author:
  -

--- a/draft-todo-yourname-protocol.md
+++ b/draft-todo-yourname-protocol.md
@@ -24,7 +24,7 @@ abbrev: "TODO - Abbreviation"
 category: info
 
 docname: draft-todo-yourname-protocol-latest
-submissiontype: IETF
+submissiontype: IETF  # also: "independent", "IAB", or "IRTF"
 number:
 date:
 consensus: true
@@ -32,8 +32,9 @@ v: 3
 area: AREA
 workgroup: WG Working Group
 keyword:
- - TODO1
- - TODO2
+ - next generation
+ - unicorn
+ - sparkling distributed ledger
 venue:
   group: WG
   type: Working Group


### PR DESCRIPTION
In particular, the IETF one removes a compilation warning and adding it requires specifying the IPR
stand_alone is required for the format we're all using for HTTP references these days
number/date/consensus/keyword make life easier during AUTH48