### PR TITLE
Adding the 2023 IETF Trust license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,12 @@
+   Copyright (c) 2023 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (https://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.


### PR DESCRIPTION
I stick the text of the IETF Trust Legal Provisions to all my I-D repos. I assume that's appropriate for both this template repo, as well as any I-D repos created from it.

(I see that your workflows automatically create a different LICENSE.md file, so maybe there's a more workflow-y way to generate this rather than committing the file?)